### PR TITLE
feat: add name property to filter logic

### DIFF
--- a/src/pages/Home/Home.vue
+++ b/src/pages/Home/Home.vue
@@ -33,9 +33,9 @@ const router = useRouter();
 
 const filteredFonts = computed(() =>
   fonts.value
-    .filter(({ fontFamily, author }) => {
+    .filter(({ fontFamily, author, name }) => {
       const re = RegExp(searchContent.value.toLowerCase());
-      return re.test(fontFamily.toLowerCase()) || re.test(author.toLowerCase());
+      return re.test(fontFamily.toLowerCase()) || re.test(author.toLowerCase()) || re.test(name.toLowerCase());
     })
     .sort(),
 );


### PR DESCRIPTION
I add name property to fonts filter logic.
Prevents '나눔고딕' not appearing even if you search for '나눔'.

Couldn't test the actual operation because I don't have env.json. 😭

## Checklist

- [x] PR contains only changes related; no stray files, etc.
