### PR TITLE
한글 초성 검색 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "file-saver": "1.3.2",
+    "hangul-chosung-search-js": "^1.1.3",
     "jszip": "^3.6.0",
     "lodash": "^4.17.21",
     "vue": "^3.1.5",

--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -2,7 +2,7 @@
   <div class="search-box">
     <span class="search-box__icon icon material-icons-outlined">search</span>
     <input-field
-      placeholder="이름으로 폰트 검색하기"
+      placeholder="이름 또는 초성으로 폰트 검색하기"
       v-model="inputSearchContent"
     />
   </div>

--- a/src/pages/Home/Home.vue
+++ b/src/pages/Home/Home.vue
@@ -12,6 +12,7 @@
 </template>
 
 <script setup>
+import * as Hangul from 'hangul-chosung-search-js';
 import ModifierBar from './ModifierBar.vue';
 import CardsPanel from './CardsPanel.vue';
 import { useStore } from 'vuex';
@@ -23,10 +24,9 @@ const { fonts, searchContent } = toRefs(store.state);
 const filteredFonts = computed(() =>
   fonts.value.filter(({ fontFamily, author, name }) => {
     const re = RegExp(searchContent.value.toLowerCase());
-    return (
-      re.test(fontFamily.toLowerCase()) ||
-      re.test(author.toLowerCase()) ||
-      re.test(name.toLowerCase())
+    return [fontFamily, author, name].some(str =>
+      re.test(str.toLowerCase()) ||
+      Hangul.isSearch(searchContent.value, str.replaceAll(/\s/g, ''))
     );
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5659,6 +5659,18 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
+hangul-chosung-search-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hangul-chosung-search-js/-/hangul-chosung-search-js-1.1.3.tgz#e27e3f2390b5c5cf66cd106e75a83196daa345df"
+  integrity sha512-BrP3Y0qq/V6fPmyz66mebjeBA2lDFUN7P2OC2uFV/qDrAb83u8rwL1+z0wFAzHV2+nYpHvCmpfVVQA6XkGU36g==
+  dependencies:
+    hangul-js "^0.2.5"
+
+hangul-js@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/hangul-js/-/hangul-js-0.2.6.tgz#3e552e3a68c76498cf2c7993ca354af7bad4730d"
+  integrity sha512-48axU8LgjCD30FEs66Xc04/8knxMwCMQw0f67l67rlttW7VXT3qRJgQeHmhiuGwWXGvSbk6YM0fhQlcjE1JFQA==
+
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"


### PR DESCRIPTION
Closes #37.

[hangul-chosung-search-js](https://www.npmjs.com/package/hangul-chosung-search-js)를 이용해 한글 초성 검색 기능을 추가합니다.
- 검색 대상에 있는 공백은 무시합니다. (ㅂㄷㅇㅁㅈ -> "배달의 민족"을 검색 결과에 포함)

p.s. 
- 스토리북이 있길래 searchBar에서의 동작을 확인해보고 싶었는데 state가 없다면서 오류가 나서, 그냥 이만큼만 추가했습니다. 
- prettier나 eslint, typescript(이건 #44 가 있지만) 세팅이 있으면 기여하기 좀 더 편할 것 같습니다.

감사합니다!